### PR TITLE
Replace recursion with loop in mercenary AI

### DIFF
--- a/AI_xatiya/AI_M.lua
+++ b/AI_xatiya/AI_M.lua
@@ -13,18 +13,19 @@ dofile("./AI_xatiya/Control.lua")
 if not _G.__MERCENARY_AI_LOOP_STARTED then
     _G.__MERCENARY_AI_LOOP_STARTED = true
     local function mercenary_ai_loop()
-        if type(AI) == "function" and MyID then
-            pcall(function() AI(MyID) end)
+        while true do
+            if type(AI) == "function" and MyID then
+                pcall(function() AI(MyID) end)
+            end
+            -- Ejecutar cada 200 ms
+            if type(package) == "table" and package.loaded and package.loaded["socket"] then
+                package.loaded["socket"].sleep(0.2)
+            else
+                -- fallback para entornos sin socket
+                local t0 = os.clock()
+                while os.clock() - t0 < 0.2 do end
+            end
         end
-        -- Ejecutar cada 200 ms
-        if type(package) == "table" and package.loaded and package.loaded["socket"] then
-            package.loaded["socket"].sleep(0.2)
-        else
-            -- fallback para entornos sin socket
-            local t0 = os.clock()
-            while os.clock() - t0 < 0.2 do end
-        end
-        mercenary_ai_loop()
     end
     -- Inicializar MyID si es necesario
     if not MyID and type(GetV) == "function" and type(GetActors) == "function" then


### PR DESCRIPTION
## Summary
- Avoid stack growth by running mercenary AI in an endless loop instead of recursion
- Pause 200ms between AI cycles and call AI(MyID) using `pcall`

## Testing
- `luac -p AI_xatiya/AI_M.lua`


------
https://chatgpt.com/codex/tasks/task_e_68944f0402288321b4028cb506b81f26