### PR TITLE
Ensure homunculus defends mercenary and prioritizes threats

### DIFF
--- a/AI_xatiya/Actor_Presets.txt
+++ b/AI_xatiya/Actor_Presets.txt
@@ -77,9 +77,9 @@ Preset[ASSASSIN_CROSS]=EMPBREAKTARGET
 -- MONSTRUOS
 ----------------------------------------------------------------
 
-Preset[1884]=PRIORITYTARGET   --Mavka
-Preset[1883]=IGNORETARGET   --Uzhas
-Preset[1882]=IGNORETARGET   --Baba Yaga
+Preset[1884]=LOWPRIORITYTARGET   --Mavka
+Preset[1883]=PRIORITYTARGET   --Uzhas
+Preset[1882]=PRIORITYTARGET   --Baba Yaga
 Preset[1035]=IGNORETARGET   --hunter fly
 Preset[1139]=IGNORETARGET   --mantis
 Preset[1078]=IGNORETARGET   --red plant

--- a/AI_xatiya/Control.lua
+++ b/AI_xatiya/Control.lua
@@ -83,17 +83,23 @@ function OnOwnerHit(attackerId)
 end
 
 function OnMercenaryHit(attackerId)
-	ChaseTarget = attackerId
-	if Dt[attackerId] ~= nil then
-	Dt[attackerId][TARGET_ALLIANCE] = ENEMY
-	end
-	if ScreenEnemies then
-	ScreenEnemies[attackerId] = 1000
-	end
+        ChaseTarget = attackerId
+        if Dt[attackerId] ~= nil then
+                Dt[attackerId][TARGET_ALLIANCE] = ENEMY
+                if Dt[attackerId][TARGET_TYPE] == IGNORETARGET or Dt[attackerId][TARGET_TYPE] == PASSIVETARGET then
+                        Dt[attackerId][TARGET_TYPE] = PRIORITYTARGET
+                end
+        end
+        if ScreenEnemies then
+                ScreenEnemies[attackerId] = 1000
+        end
 end
 
 if RegisterMercenaryDamageCallback then
-	RegisterMercenaryDamageCallback(OnMercenaryHit)
+        RegisterMercenaryDamageCallback(OnMercenaryHit)
+end
+if RegisterOwnerDamageCallback then
+        RegisterOwnerDamageCallback(OnOwnerHit)
 end
 
 ------------- command process  ---------------------


### PR DESCRIPTION
## Summary
- Make mercenary damage callbacks reclassify attackers as enemies and register owner damage handler
- Prioritize Baba Yaga and Uzhas over Mavkas in actor presets

## Testing
- `luac -p AI_xatiya/Control.lua`
- `luac -p AI_xatiya/Actor_Presets.txt`


------
https://chatgpt.com/codex/tasks/task_e_689481d874fc8321b004b9a4b78ca19f