### PR TITLE
Prioritize Mavka for mercenary AI

### DIFF
--- a/AI_xatiya/Actor_Presets.txt
+++ b/AI_xatiya/Actor_Presets.txt
@@ -77,7 +77,7 @@ Preset[ASSASSIN_CROSS]=EMPBREAKTARGET
 -- MONSTRUOS
 ----------------------------------------------------------------
 
-Preset[1884]=LOWPRIORITYTARGET   --Mavka
+Preset[1884]=PRIORITYTARGET      --Mavka (prioridad ajustada para ataques constantes)
 Preset[1883]=PRIORITYTARGET   --Uzhas
 Preset[1882]=PRIORITYTARGET   --Baba Yaga
 Preset[1035]=IGNORETARGET   --hunter fly

--- a/AI_xatiya/USER_AI/Actor_Presets.lua
+++ b/AI_xatiya/USER_AI/Actor_Presets.lua
@@ -3,8 +3,8 @@ MyPresets = {
         Name = "Mavka",
         Type = "MONSTER",
         Alliance = "AGGRESSIVE",
-        Priority = 50,
-        ForceTarget = 0,       -- No fuerza que sea objetivo
+        Priority = 100,        -- Prioridad máxima para asegurar enfoque inmediato
+        ForceTarget = 1,       -- Fuerza que sea objetivo preferente
         ForcedTargetOnly = 0,  -- Permite cambiar a otros objetivos
         IgnoreDamage = 0,      -- No ignora daño de Mavka
 


### PR DESCRIPTION
## Summary
- Ensure mercenary focuses on Mavka by marking it as a priority target
- Force mercenary to immediately target Mavka with maximum priority

## Testing
- `luac -p USER_AI/Actor_Presets.lua`
- `luac -p Actor_Presets.txt`


------
https://chatgpt.com/codex/tasks/task_e_68948c16db6c83219c9d1d7c7a12ca5d