### PR TITLE
Fix mercenary AI skill reset for continuous attacks

### DIFF
--- a/AI_xatiya/Control.lua
+++ b/AI_xatiya/Control.lua
@@ -2036,7 +2036,7 @@ function AI(myid)
 	end
 ----------------------------------------------------------------------------------------------------------------------------
 --refreshed every cycle
-	--UsedSkill = 0
+	UsedSkill = 0
 	MyX,MyY = GetV(V_POSITION,myid)
 	MyMotion = GetV(V_MOTION,myid)
 	MyTarget = GetV(V_TARGET,myid)


### PR DESCRIPTION
## Summary
- Ensure the mercenary AI resets `UsedSkill` every cycle

## Testing
- `luac -p AI_xatiya/Control.lua`

------
https://chatgpt.com/codex/tasks/task_e_68949727486c8321af3f24a957e9422a