### PR TITLE
Add reactive aggro mode for AI

### DIFF
--- a/AI_xatiya/Control.lua
+++ b/AI_xatiya/Control.lua
@@ -452,13 +452,22 @@ function	OnFOLLOW_ST ()
 		end
 	end
 
-	-- Permitir que el mercenario ataque automáticamente enemigos cercanos como el homúnculo
-	if (SuperAggro == 1 and EnemyCount > 0 and UsedAttack == 0 and UsedSkill == 0) then
-		if (NormAtkTarget ~= 0) then
-			Attack(MyID, NormAtkTarget)
-			UsedAttack = 1
-		end
-	end
+        -- Permitir que el mercenario ataque automáticamente enemigos cercanos como el homúnculo
+        if (SuperAggro == 1 and EnemyCount > 0 and UsedAttack == 0 and UsedSkill == 0) then
+                if (NormAtkTarget ~= 0) then
+                        Attack(MyID, NormAtkTarget)
+                        UsedAttack = 1
+                end
+        elseif (SuperAggro == 0 and ReactiveAggro == 1 and EnemyCount > 0 and UsedAttack == 0 and UsedSkill == 0) then
+                if (NormAtkTarget ~= 0) then
+                        local tX, tY = GetV(V_POSITION, NormAtkTarget)
+                        local tDistance = GetDistance(MyX, MyY, tX, tY)
+                        if (tDistance <= MyAttackRange) then
+                                Attack(MyID, NormAtkTarget)
+                                UsedAttack = 1
+                        end
+                end
+        end
 
 	--if (MyDistance <= FollowMax) then
 	if (MyDistance <= FollowMax and (MyDistance > 2 or MyMotion ~= MOTION_MOVE or PatrolDistance > 0)) then

--- a/AI_xatiya/USER_AI/GUIA.txt
+++ b/AI_xatiya/USER_AI/GUIA.txt
@@ -444,6 +444,8 @@ Homúnculo "no agresivos" (Lif, Amistr): Solo considerarán como enemigos a los 
 
 Homúnculo "agresivos" (Filir, Vanilmirth): Considerarán como enemigos a , incluso si no les están atacando directamente.todos los monstruos que estén a la vista
 
+Homúnculo "reactivos" (modo opcional): Atacan al enemigo más cercano solo si se encuentra dentro de su rango de ataque, sin perseguirlo fuera de este.
+
 function  GetMyEnemy (myid)  -- Función para buscar enemigos del Homunculus
     local result = 0
     local type = GetV (V_HOMUNTYPE,myid) -- Obtiene el tipo de Homunculus

--- a/AI_xatiya/USER_AI/HomConfigCustom.txt
+++ b/AI_xatiya/USER_AI/HomConfigCustom.txt
@@ -221,6 +221,8 @@ SuperAggro		 = 1	-- **¿Atacar a todo enemigo visible?**
                     -- **0 = No, 1 = Sí.** Si se habilita, el homúnculo atacará automáticamente a cualquier enemigo que entre en su rango de visión, sin necesidad de orden manual.
                     -- **Útil en PvM para un farmeo más eficiente.**
                     -- **Puede ser problemático en PvP o mapas con muchos jugadores**, donde el homúnculo podría atraer enemigos no deseados.
+ReactiveAggro           = 0    -- **¿Responder atacando sin perseguir?**
+                    -- **0 = No, 1 = Sí.** Con 'SuperAggro' desactivado, el homúnculo atacará al enemigo más cercano solo si está dentro de su rango de ataque. No lo perseguirá fuera de ese rango.
 AggroHP		 = 0	 -- **HP mínimo del enemigo para atacar.**
                     -- **0 = Siempre ataca, incluso a enemigos con HP completo.**
                     -- Si se establece un valor mayor a 0, el homúnculo solo atacará enemigos cuyo HP esté por debajo de este valor. (Actualmente no funcional o implementado).

--- a/AI_xatiya/USER_AI/MerConfigCustom.txt
+++ b/AI_xatiya/USER_AI/MerConfigCustom.txt
@@ -238,6 +238,8 @@ FriendPriority     = 0     -- [AVANZADO - PRIORIDAD] Prioridad para atacar objet
 
 SuperAggro         = 1     -- [AVANZADO - AGRESIVIDAD] Activa (1) o desactiva (0) el modo 'Super Aggro'. El mercenario intentará atacar a todos los enemigos posibles.
                                 -- ÚTIL en PvM (Jugador vs Monstruo). Puede ser problemático en salas PvP concurridas.
+ReactiveAggro       = 0     -- [AVANZADO - AGRESIVIDAD] Ataca solo objetivos en rango, sin perseguirlos.
+                                -- Activo (1): Si 'SuperAggro' está desactivado, el mercenario atacará al enemigo más cercano únicamente dentro de su rango de ataque.
 AggroHP            = 0     -- [AVANZADO - AGRESIVIDAD] Porcentaje de HP del homúnculo por debajo del cual el mercenario se volverá agresivo (si 'SuperAggro' está activado).
                                 -- Si el homúnculo es atacado y su HP está por debajo de este porcentaje, el mercenario reaccionará.
                                 -- Valor 0: El mercenario siempre será agresivo si 'SuperAggro' está activado.


### PR DESCRIPTION
## Summary
- Allow mercenaries to attack nearest target without SuperAggro when ReactiveAggro is enabled
- Expose `ReactiveAggro` setting for homunculus and mercenary configs
- Document new reactive mode in user guide

## Testing
- `luac -p AI_xatiya/Control.lua`

------
https://chatgpt.com/codex/tasks/task_e_68a13f63c7f48321b49099ef132bcc2c